### PR TITLE
Do not reap pods; allow failed pods to remain for log inspection.

### DIFF
--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -11,7 +11,6 @@ module Resque
         end
 
         reap_finished_jobs
-        reap_finished_pods
         apply_kubernetes_job
       end
 
@@ -20,11 +19,6 @@ module Resque
       def jobs_client
         return @jobs_client if @jobs_client
         @jobs_client = client("/apis/batch")
-      end
-
-      def pods_client
-        return @pods_client if @pods_client
-        @pods_client = client("")
       end
 
       def client(scope)
@@ -68,15 +62,6 @@ module Resque
 
         finished.each do |job|
           jobs_client.delete_job(job.metadata.name, job.metadata.namespace)
-        end
-      end
-
-      def reap_finished_pods
-        resque_jobs = pods_client.get_pods(label_selector: "resque-kubernetes=pod")
-        finished = resque_jobs.select { |pod| pod.status.phase == "Succeeded" }
-
-        finished.each do |pod|
-          pods_client.delete_pod(pod.metadata.name, pod.metadata.namespace)
         end
       end
 

--- a/spec/resque/kubernetes/job_spec.rb
+++ b/spec/resque/kubernetes/job_spec.rb
@@ -37,11 +37,9 @@ describe Resque::Kubernetes::Job do
   subject { ThingExtendingJob }
 
   let(:jobs_client) { spy("jobs client") }
-  let(:pods_client) { spy("pods client") }
 
   before do
     allow(subject).to receive(:jobs_client).and_return(jobs_client)
-    allow(subject).to receive(:pods_client).and_return(pods_client)
   end
 
   context "#before_enqueue_kubernetes_job" do
@@ -57,7 +55,6 @@ describe Resque::Kubernetes::Job do
 
       it "calls kubernetes APIs" do
         expect(subject).to receive(:jobs_client).and_return(jobs_client)
-        expect(subject).to receive(:pods_client).and_return(pods_client)
         subject.before_enqueue_kubernetes_job
       end
     end
@@ -77,7 +74,6 @@ describe Resque::Kubernetes::Job do
 
         it "calls kubernetes APIs" do
           expect(subject).to receive(:jobs_client).and_return(jobs_client)
-          expect(subject).to receive(:pods_client).and_return(pods_client)
           subject.before_enqueue_kubernetes_job
         end
       end
@@ -89,7 +85,6 @@ describe Resque::Kubernetes::Job do
 
         it "does not make any kubernetes calls" do
           expect(subject).not_to receive(:jobs_client)
-          expect(subject).not_to receive(:pods_client)
           subject.before_enqueue_kubernetes_job
         end
       end
@@ -98,12 +93,6 @@ describe Resque::Kubernetes::Job do
     it "reaps any completed jobs matching our label" do
       expect(jobs_client).to receive(:get_jobs).with(label_selector: "resque-kubernetes=job").and_return([working_job, done_job])
       expect(jobs_client).to receive(:delete_job).with(done_job.metadata.name, done_job.metadata.namespace)
-      subject.before_enqueue_kubernetes_job
-    end
-
-    it "reaps all completed pods of the jobs matching our label" do
-      expect(pods_client).to receive(:get_pods).with(label_selector: "resque-kubernetes=pod").and_return([working_pod, done_pod])
-      expect(pods_client).to receive(:delete_pod).with(done_pod.metadata.name, done_pod.metadata.namespace)
       subject.before_enqueue_kubernetes_job
     end
 


### PR DESCRIPTION
Addresses #1.

When the pod reaper runs it removes all pods where `pod.status.phase == "Succeeded"`. Apparently this includes pods that were OOMKilled. The Kubernetes docs state "When you delete the job using kubectl, all the pods it created are deleted too." So we no longer need to reap pods and if a pod fails we would like to have it around to inspect the logs and events.