### PR TITLE
Add rubocop, bunder-audit, and refactor to comply with rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,48 @@
+Documentation:
+  Exclude:
+    - "**/railtie.rb"
+    - "spec/**/*"
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Metrics/LineLength:
+  Max: 120
+Layout/AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+Style/RaiseArgs:
+  EnforcedStyle: compact
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+Layout/IndentArray:
+  IndentationWidth: 4
+Layout/IndentHash:
+  IndentationWidth: 4
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_inside_condition
+Layout/FirstParameterIndentation:
+  IndentationWidth: 4
+Layout/MultilineOperationIndentation:
+  IndentationWidth: 4
+  EnforcedStyle: indented
+Style/FormatStringToken:
+  EnforcedStyle: template
+Style/AsciiComments:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - "keylime-service-api.gemspec"
+    - "spec/**/*"
+
+Layout/EmptyLinesAroundBlockBody:
+  Exclude:
+    - "spec/**/*"
+
+Lint/UselessSetterCall:
+  Exclude:
+    # Rubocop is incorrectly flagging `term_on_empty` as local
+    # See: https://github.com/bbatsov/rubocop/issues/5420
+    - lib/resque/kubernetes/job.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in resque-kubernetes.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ class ResourceIntensiveJob
   
   def job_manifest
     <<-EOD
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: worker-job
 spec:

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,16 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "rubocop/rake_task"
+require "bundler/audit/task"
 
 RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new
+Bundler::Audit::Task.new
 
-task :default => :spec
+# Remove default and replace with a series of test tasks
+task default: []
+Rake::Task[:default].clear
+
+task default: %w[spec rubocop bundle:audit]

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "resque/kubernetes"

--- a/lib/resque/kubernetes.rb
+++ b/lib/resque/kubernetes.rb
@@ -1,9 +1,15 @@
+# frozen_string_literal: true
+
+require "resque/kubernetes/context_factory"
+require "resque/kubernetes/deep_hash"
+require "resque/kubernetes/dns_safe_random"
 require "resque/kubernetes/job"
 require "resque/kubernetes/version"
 require "resque/kubernetes/worker"
 require "resque/kubernetes/configurable"
 
 module Resque
+  # Run Resque Jobs as Kubernetes Jobs with autoscaling.
   module Kubernetes
     extend Configurable
 

--- a/lib/resque/kubernetes/configurable.rb
+++ b/lib/resque/kubernetes/configurable.rb
@@ -1,11 +1,17 @@
+# frozen_string_literal: true
+
 module Resque
   module Kubernetes
+    # Provides configuration settings, with default values, for the gem.
     module Configurable
-
       def configuration
         yield self
       end
 
+      # Define a configuration setting and its default value.
+      #
+      # name:    The name of the setting.
+      # default: A default value for the setting. (Optional)
       def define_setting(name, default = nil)
         class_variable_set("@@#{name}", default)
 
@@ -14,7 +20,7 @@ module Resque
         end
 
         define_class_method name do
-         class_variable_get("@@#{name}")
+          class_variable_get("@@#{name}")
         end
       end
 
@@ -25,8 +31,6 @@ module Resque
           define_method(name, &block)
         end
       end
-
-
-     end
+    end
   end
 end

--- a/lib/resque/kubernetes/context_factory.rb
+++ b/lib/resque/kubernetes/context_factory.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "kubeclient"
+
+module Resque
+  module Kubernetes
+    # Create a context for `Kubeclient` depending on the environment.
+    class ContextFactory
+      class << self
+        def context
+          # TODO: Add ability to load this from config
+
+          if File.exist?("/var/run/secrets/kubernetes.io/serviceaccount/token")
+            # When running in GKE/k8s cluster, use the service account secret token and ca bundle
+            well_known_context
+          elsif File.exist?(kubeconfig)
+            # When running in development, use the config file for `kubectl` and default application credentials
+            kubectl_context
+          end
+        end
+
+        private
+
+        def well_known_context
+          Kubeclient::Config::Context.new(
+              "https://kubernetes",
+              "v1",
+              {ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
+              bearer_token_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          )
+        end
+
+        def kubectl_context
+          config = Kubeclient::Config.read(kubeconfig)
+          Kubeclient::Config::Context.new(
+              config.context.api_endpoint,
+              config.context.api_version,
+              config.context.ssl_options,
+              use_default_gcp: true
+          )
+        end
+
+        def kubeconfig
+          File.join(ENV["HOME"], ".kube", "config")
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/kubernetes/deep_hash.rb
+++ b/lib/resque/kubernetes/deep_hash.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Resque
+  module Kubernetes
+    # A subclass of Hash that allows nested keys to be added
+    # and ensures the interim hashes exist.
+    class DeepHash < Hash
+      # Add keys and a value to nested hashes.
+      #
+      # keys:  An array of keys.
+      # value: A value to assign to the key in the ultimate hash.
+      #
+      # Example:
+      #     h = DeepHash.new
+      #     h.deep_add(%w[one two three], "deep")
+      #     deep = h["one"]["two"]["three"]
+      def deep_add(keys, value)
+        last_key = keys.pop
+
+        m = self
+        keys.each do |key|
+          m[key] ||= {}
+          m = m[key]
+        end
+
+        m[last_key] = value
+
+        m
+      end
+    end
+  end
+end

--- a/lib/resque/kubernetes/dns_safe_random.rb
+++ b/lib/resque/kubernetes/dns_safe_random.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module Resque
+  module Kubernetes
+    # Simple utility to generate a string of DNS-safe characters.
+    #
+    # Example:
+    #     str = DNSSafeRandom.random_characters
+    class DNSSafeRandom
+      class << self
+        # Returns an n-length string of DNS-safe characters.
+        #
+        # n: The number of characters to return (default 5).
+        def random_chars(n = 5)
+          s = [SecureRandom.random_bytes(n)].pack("m*")
+          s.delete!("=\n")
+          s.tr!("+/_-", "0")
+          s.tr!("A-Z", "a-z")
+          s[0...n]
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/kubernetes/version.rb
+++ b/lib/resque/kubernetes/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Resque
   module Kubernetes
     VERSION = "0.4.0"

--- a/lib/resque/kubernetes/worker.rb
+++ b/lib/resque/kubernetes/worker.rb
@@ -1,7 +1,19 @@
+# frozen_string_literal: true
+
 require "resque"
 
 module Resque
   module Kubernetes
+    # Patches the resque worker to terminate when the queue is empty.
+    #
+    # This patch enables setting an environment variable, `TERM_ON_EMPTY`
+    # that causes the worker to shutdown when the queue no longer has any
+    # resque jobs. This allows running workers as Kuberenetes Jobs that will
+    # terminate when there is no longer any work to do.
+    #
+    # To use, make sure that the container images that hold your workers are
+    # built to include the `resque-kubernetes` gem and set `TERM_ON_EMPTY` in
+    # their environment to a truthy value (e.g. "1").
     module Worker
       def self.included(base)
         base.class_eval do
@@ -11,6 +23,7 @@ module Resque
 
       attr_accessor :term_on_empty
 
+      # Replace methods on the worker instance
       module InstanceMethods
         def prepare
           self.term_on_empty = ENV["TERM_ON_EMPTY"] if ENV["TERM_ON_EMPTY"]
@@ -29,13 +42,11 @@ module Resque
         end
       end
 
-
       private
 
       def queues_empty?
-        queues.all? { |queue| Resque.size(queue) == 0 }
+        queues.all? { |queue| Resque.size(queue).zero? }
       end
-
     end
   end
 end

--- a/resque-kubernetes.gemspec
+++ b/resque-kubernetes.gemspec
@@ -1,7 +1,9 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+
+# frozen_string_literal: true
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'resque/kubernetes/version'
+require "resque/kubernetes/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "resque-kubernetes"
@@ -9,8 +11,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Jeremy Wadsack"]
   spec.email         = ["jeremy.wadsack@gmail.com"]
 
-  spec.summary       = %q{Run Resque Jobs as Kubernetes Jobs}
-  spec.description   = %q{Launches a Kubernetes Job when a Resque Job is enqueued, then terminates the worker when there are no more jobs in the queue.}
+  spec.summary       = "Run Resque Jobs as Kubernetes Jobs"
+  spec.description   = "Launches a Kubernetes Job when a Resque Job is enqueued, then " \
+                       "terminates the worker when there are no more jobs in the queue."
   spec.homepage      = "https://github.com/keylimetoolbox/resque-kubernetes"
   spec.license       = "MIT"
 
@@ -21,10 +24,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler-audit", "~> 0"
+  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "rspec", "~> 3.7"
+  spec.add_development_dependency "rubocop", "~> 0.52", ">= 0.52.1"
 
-  spec.add_dependency "resque", "~> 1.26"
   spec.add_dependency "kubeclient", "~> 2.2"
+  spec.add_dependency "resque", "~> 1.26"
 end

--- a/spec/resque/kubernetes/worker_spec.rb
+++ b/spec/resque/kubernetes/worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Resque::Kubernetes::Worker do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "resque/kubernetes"
-
 
 def with_term_on_empty(value)
   old_value = ENV["TERM_ON_EMPTY"]


### PR DESCRIPTION
In line with our guidelines, this adds `rubocop` and `bundler-audit` to the development dependencies. I updated the default `rake` task to run `rspec`, `rubocop`, then `bundler-audit` — that should match the order in which you're most likely going to address issues and test.

I updated the code base to comply with our `rubocop` guidelines. This includes extracting some utility functions / repeated patterns to dedicated classes (`DeepHash`, `DNSSafeRandom`, `ContextFactory`).