### PR TITLE
Gracefully continue if the job to reap was removed by another process

### DIFF
--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -75,7 +75,11 @@ module Resque
 
       def reap_finished_jobs
         finished_jobs.each do |job|
-          jobs_client.delete_job(job.metadata.name, job.metadata.namespace)
+          begin
+            jobs_client.delete_job(job.metadata.name, job.metadata.namespace)
+          rescue KubeException => e
+            raise unless e.error_code == 404
+          end
         end
       end
 


### PR DESCRIPTION
Addresses issue #2 (internal bug #154036576).

When two jobs are added at about the same time and they both try to clean up completed jobs, one of them can get a 404 error for a completed job in the list because it was removed by the other reaper.

This gracefully handles that by ignoring a 404 error when deleting a Kubernetes job.
