### PR TITLE
Allow maximum number of workers to be configured per job type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,30 @@ it.
 
 If you don't want more than one job running at a time then set this to 1.
 
+Beyond this global scope you can adjust the total number of workers on each
+individual Resque Job type by overriding the `max_workers` class method for the job.
+If you change this, the value returned by that method takes precedence over the
+global value.
+
+```ruby
+class ResourceIntensiveJob
+  extend Resque::Kubernetes::Job
+
+  def perform
+    # ...
+  end
+
+  def job_manifest
+    # ...
+  end
+
+  def max_workers
+    # Simply return an integer value, or do something more complicated if needed.
+    105
+  end
+end
+```
+
 ## To Do
 
 - We probably need better namespace support, particularly for reaping 

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -49,6 +49,32 @@ module Resque
         apply_kubernetes_job
       end
 
+      protected
+
+      # Return the maximum number of workers to autoscale the job to.
+      #
+      # While the number of active Kubernetes Jobs is less than this number,
+      # the gem will add new Jobs to auto-scale the workers.
+      #
+      # By default, this returns `Resque::Kubernetes.max_workers` from the gem
+      # configuration. You may override this method to return any other value,
+      # either as a simple integer or with some complex logic.
+      #
+      # Example:
+      #    def max_workers
+      #      # A simple integer
+      #      105
+      #    end
+      #
+      # Example:
+      #    def max_workers
+      #      # Scale based on time of day
+      #      Time.now.hour < 8 ? 15 : 5
+      #    end
+      def max_workers
+        Resque::Kubernetes.max_workers
+      end
+
       private
 
       def jobs_client
@@ -98,7 +124,7 @@ module Resque
             namespace:      namespace
         )
         running = resque_jobs.reject { |job| job.spec.completions == job.status.succeeded }
-        running.size == Resque::Kubernetes.max_workers
+        running.size == max_workers
       end
 
       def adjust_manifest(manifest)


### PR DESCRIPTION
Addresses #3.

We have instances where we would like to have the maximum number of workers depend on the type of Resque Job. For example, we have remote instances that are spun up by a worker, do some work, and then terminate. We could scale this as much as we wanted. In the same project we have workers that are pulling data into the database and we want to limit the number of those so that we aren't overburdening the database server.

This modifies the `Job` module to include a `max_workers` method (that becomes a class method for the resque job class that it's extended into). By default this returns the globally set maximum, but can be overridden to define a different value for each class.
