### PR TITLE
Use Google Default Application Credentials when authorization fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,35 +38,36 @@ Or install it yourself as:
 For any Resque job that you want to run in a Kubernetes job, you'll need to
 modify the job class with two things:
 
-- extend the class with `Resque::Kubernetes::Job`
-- and add a method `job_manifest` that returns the Kubernetes manifest for the job
+- `extend` the class with `Resque::Kubernetes::Job`
+- add a class method `job_manifest` that returns the Kubernetes manifest for the job
 
 ```ruby
 class ResourceIntensiveJob
   extend Resque::Kubernetes::Job
-  
-  def perform
-    # ... your existing code
-  end
-  
-  def job_manifest
-    <<-EOD
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: worker-job
-spec:
-  template:
-    metadata:
-      name: worker-job
-    spec:
-      containers:
-      - name: worker
-        image: us.gcr.io/project-id/some-resque-worker
-        env:
-        - name: QUEUE
-          value: high-memory
-    EOD
+  class << self
+    def perform
+      # ... your existing code
+    end
+
+    def job_manifest
+      <<~MANIFEST
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: worker-job
+        spec:
+          template:
+            metadata:
+              name: worker-job
+            spec:
+              containers:
+              - name: worker
+                image: us.gcr.io/project-id/some-resque-worker
+                env:
+                - name: QUEUE
+                  value: high-memory
+      MANIFEST
+    end
   end
 end
 ```
@@ -124,17 +125,19 @@ global value.
 class ResourceIntensiveJob
   extend Resque::Kubernetes::Job
 
-  def perform
-    # ...
-  end
+  class << self
+    def perform
+      # ...
+    end
 
-  def job_manifest
-    # ...
-  end
+    def job_manifest
+      # ...
+    end
 
-  def max_workers
-    # Simply return an integer value, or do something more complicated if needed.
-    105
+    def max_workers
+      # Simply return an integer value, or do something more complicated if needed.
+      105
+    end
   end
 end
 ```

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -13,29 +13,30 @@ module Resque
     #
     #     class ResourceIntensiveJob
     #       extend Resque::Kubernetes::Job
+    #       class << self
+    #         def perform
+    #           # ... your existing code
+    #         end
     #
-    #       def perform
-    #         # ... your existing code
-    #       end
-    #
-    #       def job_manifest
-    #         <<-EOD
-    #     apiVersion: batch/v1
-    #     kind: Job
-    #     metadata:
-    #       name: worker-job
-    #     spec:
-    #       template:
-    #         metadata:
-    #           name: worker-job
-    #         spec:
-    #           containers:
-    #           - name: worker
-    #             image: us.gcr.io/project-id/some-resque-worker
-    #             env:
-    #             - name: QUEUE
-    #               value: high-memory
-    #         EOD
+    #         def job_manifest
+    #           <<~MANIFEST
+    #           apiVersion: batch/v1
+    #             kind: Job
+    #             metadata:
+    #               name: worker-job
+    #            spec:
+    #               template:
+    #                 metadata:
+    #                   name: worker-job
+    #                 spec:
+    #                   containers:
+    #                   - name: worker
+    #                     image: us.gcr.io/project-id/some-resque-worker
+    #                     env:
+    #                     - name: QUEUE
+    #                       value: high-memory
+    #           MANIFEST
+    #         end
     #       end
     #     end
     module Job


### PR DESCRIPTION
There are [lots of ways that you can authorize `kubeclient` for a resque cluster](). I had written this to support only the two that we needed: GKE and a local dev machine. The "local dev machine" option expected the machine to have `kubectl` (to have `~/.kube/config`) that had been configured by `gcloud`. Unfortunately, it only worked with the fork of `kubeclient` for abonas/kubeclient#213. 

As that PR has been open for 18 months (and I've finally focused on a coupe solutions), this change fixes `resque-kuberenetes` to use a more reasonable approach: If the configured system fails to generate authentication options (because `gcloud`-configued `kubectl` isn't supported by `kubeclient` — see abonas/kubeclient#210) it checks if `googleauth` gem is installed, if the `.kube/config` context was created by `gcp` and then uses the default application credentials if it can find them.

This also includes a fix to the documentation to reflect that resque jobs use class methods.