### PR TITLE
Add support for ActiveJob (when backed by Resque)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,7 +34,7 @@ Style/AsciiComments:
 
 Metrics/BlockLength:
   Exclude:
-    - "keylime-service-api.gemspec"
+    - "*.gemspec"
     - "spec/**/*"
 
 Layout/EmptyLinesAroundBlockBody:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.3.1
-before_install: gem install bundler -v 1.13.6

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ class ResourceIntensiveJob
     end
 
     def job_manifest
-      YAML.load(
+      YAML.safe_load(
         <<~MANIFEST
           apiVersion: batch/v1
           kind: Job
@@ -98,7 +98,7 @@ class ResourceIntensiveJob < ApplicationJob
   end
 
   def job_manifest
-    YAML.load(
+    YAML.safe_load(
       <<~MANIFEST
         apiVersion: batch/v1
         kind: Job

--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # Resque::Kubernetes
 
-Run Resque Jobs as Kubernetes Jobs!
+Run Resque (and ActiveJob) Workers as Kubernetes Jobs!
 
 Kubernetes has a concept of "Job" which is a pod that runs a container until
 the container finishes and then it terminates the pod (as opposed to trying to
 restart the container).
 
-This gem takes advantage of that feature by starting up a Kubernetes Job when 
-a Resque Job is enqueued. It then allows the Resque Worker to be modified to 
-terminate when there are no more jobs in the queue.
+This gem takes advantage of that feature by starting up a Kubernetes Job to
+run a worker when a Resque job or ActiveJob is enqueued. It then allows the
+Resque worker to be modified to terminate when there are no more jobs in the queue.
 
 Why would you do this?
 
 We have unpredictable, resource-intensive jobs. Rather than dedicating large 
 nodes in our cluster to run the resque workers, where the resources would be 
 idle when there are no jobs to run, we can use auto-scaling to add nodes when
-Kubernetes Job gets created and shut them down when those jobs are complete. 
+a Kubernetes Job gets created and shut them down when those jobs are complete. 
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'resque-kubernetes'
+gem "resque-kubernetes"
 ```
 
 And then execute:
@@ -35,8 +35,14 @@ Or install it yourself as:
 
 ## Usage
 
-For any Resque job that you want to run in a Kubernetes job, you'll need to
-modify the job class with two things:
+This works with native/pure Resque jobs and with ActiveJob _backed by Resque_.
+Under ActiveJob, the workers are still Resque workers, so the same set up 
+applies. You just configure the job class differently.
+
+### Pure Resque
+
+For any Resque job that you want to run in a Kubernetes job, you'll need
+to modify the class with two things:
 
 - `extend` the class with `Resque::Kubernetes::Job`
 - add a class method `job_manifest` that returns the Kubernetes manifest for the job
@@ -72,12 +78,58 @@ class ResourceIntensiveJob
 end
 ```
 
+### ActiveJob (on Resque)
+
+For any ActiveJob that you want to run in a Kubernetes job, you'll need to
+modify the class with two things:
+
+- `include` `Resque::Kubernetes::Job` in the class
+- add an instance method `job_manifest` that returns the Kubernetes manifest for the job
+
+```ruby
+class ResourceIntensiveJob < ApplicationJob
+  include Resque::Kubernetes::Job
+  def perform
+    # ... your existing code
+  end
+
+  def job_manifest
+    <<~MANIFEST
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: worker-job
+      spec:
+        template:
+          metadata:
+            name: worker-job
+          spec:
+            containers:
+            - name: worker
+              image: us.gcr.io/project-id/some-resque-worker
+              env:
+              - name: QUEUE
+                value: high-memory
+    MANIFEST
+  end
+end
+```
+
+### Workers (for both)
+
 Make sure that the container image above, which is used to run the resque 
 worker, is built to include the `resque-kubernetes` gem as well. The gem will 
 add `TERM_ON_EMPTY` to the environment variables. This tells the worker that 
 whenever the queue is empty it should terminate the worker. Kubernetes will 
 then terminate the Job when the container is done running and will release the 
 resources.
+
+### Job manifest
+
+In the example above we returned the manifest as a string, just to make it
+simple. But you could also read this from a file or anything else you 
+want to do in the method, as long as you return a valid Kubernetes Job 
+manifest. 
 
 ## Configuration
 

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -40,6 +40,12 @@ module Resque
     #       end
     #     end
     module Job
+
+      def self.included(base)
+        return unless base.respond_to?(:before_enqueue)
+        base.before_enqueue :before_enqueue_kubernetes_job
+      end
+
       # A before_enqueue hook that adds worker jobs to the cluster.
       def before_enqueue_kubernetes_job(*_)
         if defined? Rails

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -24,7 +24,7 @@ module Resque
     #         end
     #
     #         def job_manifest
-    #           YAML.load(
+    #           YAML.safe_load(
     #             <<~MANIFEST
     #             apiVersion: batch/v1
     #               kind: Job
@@ -56,7 +56,7 @@ module Resque
     #       end
     #
     #       def job_manifest
-    #         YAML.load(
+    #         YAML.safe_load(
     #           <<~MANIFEST
     #           apiVersion: batch/v1
     #             kind: Job

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -19,23 +19,25 @@ module Resque
     #         end
     #
     #         def job_manifest
-    #           <<~MANIFEST
-    #           apiVersion: batch/v1
-    #             kind: Job
-    #             metadata:
-    #               name: worker-job
-    #            spec:
-    #               template:
-    #                 metadata:
-    #                   name: worker-job
-    #                 spec:
-    #                   containers:
-    #                   - name: worker
-    #                     image: us.gcr.io/project-id/some-resque-worker
-    #                     env:
-    #                     - name: QUEUE
-    #                       value: high-memory
-    #           MANIFEST
+    #           YAML.load(
+    #             <<~MANIFEST
+    #             apiVersion: batch/v1
+    #               kind: Job
+    #               metadata:
+    #                 name: worker-job
+    #              spec:
+    #                 template:
+    #                   metadata:
+    #                     name: worker-job
+    #                   spec:
+    #                     containers:
+    #                     - name: worker
+    #                       image: us.gcr.io/project-id/some-resque-worker
+    #                       env:
+    #                       - name: QUEUE
+    #                         value: high-memory
+    #             MANIFEST
+    #           )
     #         end
     #       end
     #     end

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -6,10 +6,15 @@ module Resque
   module Kubernetes
     # Resque hook to autoscale Kubernetes Jobs for workers.
     #
-    # To use, extend your Resque job class with this module and then define a
-    # class method `job_manifest` that produces the Kubernetes Job manifest.
+    # To use with pure Resque, extend your Resque job class with this module
+    # and then define a class method `job_manifest` that produces the
+    # Kubernetes Job manifest.
     #
-    # Example:
+    # To use with ActiveJob, include this module in your ActiveJob class
+    # and then define an instance method `job_manifest` that produces the
+    # Kubernetes Job manifest.
+    #
+    # Example (pure Resque):
     #
     #     class ResourceIntensiveJob
     #       extend Resque::Kubernetes::Job
@@ -25,7 +30,7 @@ module Resque
     #               kind: Job
     #               metadata:
     #                 name: worker-job
-    #              spec:
+    #               spec:
     #                 template:
     #                   metadata:
     #                     name: worker-job
@@ -39,6 +44,37 @@ module Resque
     #             MANIFEST
     #           )
     #         end
+    #       end
+    #     end
+    #
+    # Example (ActiveJob backed by Resque):
+    #
+    #     class ResourceIntensiveJob < ApplicationJob
+    #       include Resque::Kubernetes::Job
+    #       def perform
+    #         # ... your existing code
+    #       end
+    #
+    #       def job_manifest
+    #         YAML.load(
+    #           <<~MANIFEST
+    #           apiVersion: batch/v1
+    #             kind: Job
+    #              metadata:
+    #                name: worker-job
+    #              spec:
+    #                template:
+    #                  metadata:
+    #                    name: worker-job
+    #                  spec:
+    #                    containers:
+    #                    - name: worker
+    #                      image: us.gcr.io/project-id/some-resque-worker
+    #                      env:
+    #                      - name: QUEUE
+    #                        value: high-memory
+    #           MANIFEST
+    #         )
     #       end
     #     end
     module Job

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -40,7 +40,6 @@ module Resque
     #       end
     #     end
     module Job
-
       def self.included(base)
         return unless base.respond_to?(:before_enqueue)
         base.before_enqueue :before_enqueue_kubernetes_job

--- a/spec/resque/kubernetes/job_spec.rb
+++ b/spec/resque/kubernetes/job_spec.rb
@@ -22,6 +22,25 @@ describe Resque::Kubernetes::Job do
     end
   end
 
+  class ThingIncludingJob
+    include Resque::Kubernetes::Job
+
+    def job_manifest
+      default_manifest
+    end
+
+    def default_manifest
+      {
+          "metadata" => {"name" => "thing"},
+          "spec"     => {
+              "template" => {
+                  "spec" => {"containers" => [{}]}
+              }
+          }
+      }
+    end
+  end
+
   class K8sStub < OpenStruct
     def initialize(hash)
       new_hash = hash.merge(metadata: {namespace: "default", name: "pod-#{Time.now.to_i}"})
@@ -36,42 +55,22 @@ describe Resque::Kubernetes::Job do
     end
   end
 
-  subject { ThingExtendingJob }
-
   let(:jobs_client) { spy("jobs client") }
 
   before do
     allow(subject).to receive(:jobs_client).and_return(jobs_client)
   end
 
-  context "#before_enqueue_kubernetes_job" do
-    let(:done_job)    { K8sStub.new(spec: {completions: 1}, status: {succeeded: 1}) }
-    let(:working_job) { K8sStub.new(spec: {completions: 1}, status: {succeeded: 0}) }
-    let(:done_pod)    { K8sStub.new(status: {phase: "Succeeded"}) }
-    let(:working_pod) { K8sStub.new(status: {phase: "Running"}) }
+  shared_examples "before enqueue callback" do
+    context "#before_enqueue_kubernetes_job" do
+      let(:done_job)    { K8sStub.new(spec: {completions: 1}, status: {succeeded: 1}) }
+      let(:working_job) { K8sStub.new(spec: {completions: 1}, status: {succeeded: 0}) }
+      let(:done_pod)    { K8sStub.new(status: {phase: "Succeeded"}) }
+      let(:working_pod) { K8sStub.new(status: {phase: "Running"}) }
 
-    context "when Rails.env is not defined" do
-      before do
-        expect(defined? Rails).not_to be true
-      end
-
-      it "calls kubernetes APIs" do
-        expect(subject).to receive(:jobs_client).and_return(jobs_client)
-        subject.before_enqueue_kubernetes_job
-      end
-    end
-
-    context "when Rails.env is defined" do
-      let(:rails_stub) { Class.new }
-
-      before do
-        stub_const("Rails", rails_stub)
-        allow(rails_stub).to receive(:env).and_return("test")
-      end
-
-      context "and is included in the supported environments" do
+      context "when Rails.env is not defined" do
         before do
-          allow(Resque::Kubernetes).to receive(:environments).and_return(["test"])
+          expect(defined? Rails).not_to be true
         end
 
         it "calls kubernetes APIs" do
@@ -80,261 +79,293 @@ describe Resque::Kubernetes::Job do
         end
       end
 
-      context "and is not included in the supported environments" do
-        before do
-          allow(Resque::Kubernetes).to receive(:environments).and_return(["production"])
-        end
-
-        it "does not make any kubernetes calls" do
-          expect(subject).not_to receive(:jobs_client)
-          subject.before_enqueue_kubernetes_job
-        end
-      end
-    end
-
-    it "reaps any completed jobs matching our label" do
-      jobs = [working_job, done_job]
-      expect(jobs_client).to receive(:get_jobs).with(label_selector: "resque-kubernetes=job").and_return(jobs)
-      expect(jobs_client).to receive(:delete_job).with(done_job.metadata.name, done_job.metadata.namespace)
-      subject.before_enqueue_kubernetes_job
-    end
-
-    context "when a job is deleted while reaping completed jobs" do
-      let(:error) { KubeException.new(404, 'job "thing" not found', spy("response")) }
-
-      before do
-        allow(jobs_client).to receive(:get_jobs).and_return([working_job, done_job])
-        allow(jobs_client).to receive(:delete_job).and_raise(error)
-      end
-
-      it "gracefully continues" do
-        expect { subject.before_enqueue_kubernetes_job }.not_to raise_error
-      end
-    end
-
-    shared_examples "max workers" do
-      context "when the maximum number of matching, working jobs is met" do
-        let(:workers) { 1 }
+      context "when Rails.env is defined" do
+        let(:rails_stub) { Class.new }
 
         before do
-          allow(jobs_client).to receive(:get_jobs).and_return([working_job])
+          stub_const("Rails", rails_stub)
+          allow(rails_stub).to receive(:env).and_return("test")
         end
 
-        it "does not try to create a new job" do
-          expect(Kubeclient::Resource).not_to receive(:new)
-          subject.before_enqueue_kubernetes_job
+        context "and is included in the supported environments" do
+          before do
+            allow(Resque::Kubernetes).to receive(:environments).and_return(["test"])
+          end
+
+          it "calls kubernetes APIs" do
+            expect(subject).to receive(:jobs_client).and_return(jobs_client)
+            subject.before_enqueue_kubernetes_job
+          end
+        end
+
+        context "and is not included in the supported environments" do
+          before do
+            allow(Resque::Kubernetes).to receive(:environments).and_return(["production"])
+          end
+
+          it "does not make any kubernetes calls" do
+            expect(subject).not_to receive(:jobs_client)
+            subject.before_enqueue_kubernetes_job
+          end
         end
       end
 
-      context "when matching, completed jobs exist" do
-        let(:workers) { 2 }
+      it "reaps any completed jobs matching our label" do
+        jobs = [working_job, done_job]
+        expect(jobs_client).to receive(:get_jobs).with(label_selector: "resque-kubernetes=job").and_return(jobs)
+        expect(jobs_client).to receive(:delete_job).with(done_job.metadata.name, done_job.metadata.namespace)
+        subject.before_enqueue_kubernetes_job
+      end
+
+      context "when a job is deleted while reaping completed jobs" do
+        let(:error) { KubeException.new(404, 'job "thing" not found', spy("response")) }
 
         before do
-          allow(jobs_client).to receive(:get_jobs).and_return([done_job, working_job])
+          allow(jobs_client).to receive(:get_jobs).and_return([working_job, done_job])
+          allow(jobs_client).to receive(:delete_job).and_raise(error)
         end
 
-        it "creates a new job using the provided job manifest" do
-          expect(jobs_client).to receive(:create_job)
-          subject.before_enqueue_kubernetes_job
+        it "gracefully continues" do
+          expect { subject.before_enqueue_kubernetes_job }.not_to raise_error
         end
       end
 
-      context "when more job workers can be launched" do
-        let(:job) { double("job") }
-        let(:workers) { 10 }
+      shared_examples "max workers" do
+        context "when the maximum number of matching, working jobs is met" do
+          let(:workers) { 1 }
 
-        before do
-          allow(jobs_client).to receive(:get_jobs).and_return([])
-          allow(Kubeclient::Resource).to receive(:new).and_return(job)
+          before do
+            allow(jobs_client).to receive(:get_jobs).and_return([working_job])
+          end
+
+          it "does not try to create a new job" do
+            expect(Kubeclient::Resource).not_to receive(:new)
+            subject.before_enqueue_kubernetes_job
+          end
         end
 
-        it "creates a new job using the provided job manifest" do
-          expect(jobs_client).to receive(:create_job)
-          subject.before_enqueue_kubernetes_job
+        context "when matching, completed jobs exist" do
+          let(:workers) { 2 }
+
+          before do
+            allow(jobs_client).to receive(:get_jobs).and_return([done_job, working_job])
+          end
+
+          it "creates a new job using the provided job manifest" do
+            expect(jobs_client).to receive(:create_job)
+            subject.before_enqueue_kubernetes_job
+          end
         end
 
-        it "labels the job and the pod" do
-          manifest = hash_including(
-              "metadata" => hash_including(
-                  "labels" => hash_including(
-                      "resque-kubernetes" => "job"
-                  )
-              ),
-              "spec"     => hash_including(
-                  "template" => hash_including(
-                      "metadata" => hash_including(
-                          "labels" => hash_including(
-                              "resque-kubernetes" => "pod"
+        context "when more job workers can be launched" do
+          let(:job) { double("job") }
+          let(:workers) { 10 }
+
+          before do
+            allow(jobs_client).to receive(:get_jobs).and_return([])
+            allow(Kubeclient::Resource).to receive(:new).and_return(job)
+          end
+
+          it "creates a new job using the provided job manifest" do
+            expect(jobs_client).to receive(:create_job)
+            subject.before_enqueue_kubernetes_job
+          end
+
+          it "labels the job and the pod" do
+            manifest = hash_including(
+                "metadata" => hash_including(
+                    "labels" => hash_including(
+                        "resque-kubernetes" => "job"
+                    )
+                ),
+                "spec"     => hash_including(
+                    "template" => hash_including(
+                        "metadata" => hash_including(
+                            "labels" => hash_including(
+                                "resque-kubernetes" => "pod"
+                            )
+                        )
+                    )
+                )
+            )
+            expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
+            subject.before_enqueue_kubernetes_job
+          end
+
+          it "label the job to group it based on the provided name in the manifest" do
+            manifest = hash_including(
+                "metadata" => hash_including(
+                    "labels" => hash_including(
+                        "resque-kubernetes-group" => "thing"
+                    )
+                )
+            )
+            expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
+            subject.before_enqueue_kubernetes_job
+          end
+
+          it "updates the job name to make it unique" do
+            manifest = hash_including(
+                "metadata" => hash_including(
+                    "name" => match(/^thing-[a-z0-9]{5}$/)
+                )
+            )
+            expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
+            subject.before_enqueue_kubernetes_job
+          end
+
+          context "when the restart policy is included" do
+            before do
+              manifest = subject.default_manifest.dup
+              manifest["spec"]["template"]["spec"]["restartPolicy"] = "Always"
+              allow(subject).to receive(:job_manifest).and_return(manifest)
+            end
+
+            it "retains it" do
+              manifest = hash_including(
+                  "spec" => hash_including(
+                      "template" => hash_including(
+                          "spec" => hash_including(
+                              "restartPolicy" => "Always"
                           )
                       )
                   )
               )
-          )
-          expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
-          subject.before_enqueue_kubernetes_job
-        end
+              expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
+              subject.before_enqueue_kubernetes_job
+            end
+          end
 
-        it "label the job to group it based on the provided name in the manifest" do
-          manifest = hash_including(
-              "metadata" => hash_including(
-                  "labels" => hash_including(
-                      "resque-kubernetes-group" => "thing"
+          context "when the restart policy is not set" do
+            it "ensures it is set to OnFailure" do
+              manifest = hash_including(
+                  "spec" => hash_including(
+                      "template" => hash_including(
+                          "spec" => hash_including(
+                              "restartPolicy" => "OnFailure"
+                          )
+                      )
                   )
               )
-          )
-          expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
-          subject.before_enqueue_kubernetes_job
-        end
+              expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
+              subject.before_enqueue_kubernetes_job
+            end
+          end
 
-        it "updates the job name to make it unique" do
-          manifest = hash_including(
-              "metadata" => hash_including(
-                  "name" => match(/^thing-[a-z0-9]{5}$/)
+          context "when TERM_ON_EMPTY environment is included" do
+            before do
+              manifest = subject.default_manifest.dup
+              manifest["spec"]["template"]["spec"]["containers"][0]["env"] = [
+                  {"name" => "TERM_ON_EMPTY", "value" => "true"}
+              ]
+              allow(subject).to receive(:job_manifest).and_return(manifest)
+            end
+
+            it "ensures it is set to 1" do
+              manifest = hash_including(
+                  "spec" => hash_including(
+                      "template" => hash_including(
+                          "spec" => hash_including(
+                              "containers" => array_including(
+                                  hash_including(
+                                      "env" => array_including(
+                                          hash_including("name" => "TERM_ON_EMPTY", "value" => "1")
+                                      )
+                                  )
+                              )
+                          )
+                      )
+                  )
               )
-          )
-          expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
-          subject.before_enqueue_kubernetes_job
+              expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
+              subject.before_enqueue_kubernetes_job
+            end
+          end
+
+          context "when TERM_ON_EMPTY environment is not set" do
+            it "ensures it is set to 1" do
+              manifest = hash_including(
+                  "spec" => hash_including(
+                      "template" => hash_including(
+                          "spec" => hash_including(
+                              "containers" => array_including(
+                                  hash_including(
+                                      "env" => array_including(
+                                          hash_including("name" => "TERM_ON_EMPTY", "value" => "1")
+                                      )
+                                  )
+                              )
+                          )
+                      )
+                  )
+              )
+              expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
+              subject.before_enqueue_kubernetes_job
+            end
+          end
+
+          context "when the namespace is not included" do
+            it "sets it to 'default'" do
+              manifest = hash_including(
+                  "metadata" => hash_including(
+                      "namespace" => "default"
+                  )
+              )
+              expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
+              subject.before_enqueue_kubernetes_job
+            end
+          end
+
+          context "when the namespace is set" do
+            before do
+              manifest = subject.default_manifest.dup
+              manifest["metadata"]["namespace"] = "staging"
+              allow(subject).to receive(:job_manifest).and_return(manifest)
+            end
+
+            it "retains it" do
+              manifest = hash_including(
+                  "metadata" => hash_including(
+                      "namespace" => "staging"
+                  )
+              )
+              expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
+              subject.before_enqueue_kubernetes_job
+            end
+          end
+
         end
-
-        context "when the restart policy is included" do
-          before do
-            manifest = subject.default_manifest.dup
-            manifest["spec"]["template"]["spec"]["restartPolicy"] = "Always"
-            allow(subject).to receive(:job_manifest).and_return(manifest)
-          end
-
-          it "retains it" do
-            manifest = hash_including(
-                "spec" => hash_including(
-                    "template" => hash_including(
-                        "spec" => hash_including(
-                            "restartPolicy" => "Always"
-                        )
-                    )
-                )
-            )
-            expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
-            subject.before_enqueue_kubernetes_job
-          end
-        end
-
-        context "when the restart policy is not set" do
-          it "ensures it is set to OnFailure" do
-            manifest = hash_including(
-                "spec" => hash_including(
-                    "template" => hash_including(
-                        "spec" => hash_including(
-                            "restartPolicy" => "OnFailure"
-                        )
-                    )
-                )
-            )
-            expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
-            subject.before_enqueue_kubernetes_job
-          end
-        end
-
-        context "when TERM_ON_EMPTY environment is included" do
-          before do
-            manifest = subject.default_manifest.dup
-            manifest["spec"]["template"]["spec"]["containers"][0]["env"] = [
-                {"name" => "TERM_ON_EMPTY", "value" => "true"}
-            ]
-            allow(subject).to receive(:job_manifest).and_return(manifest)
-          end
-
-          it "ensures it is set to 1" do
-            manifest = hash_including(
-                "spec" => hash_including(
-                    "template" => hash_including(
-                        "spec" => hash_including(
-                            "containers" => array_including(
-                                hash_including(
-                                    "env" => array_including(
-                                        hash_including("name" => "TERM_ON_EMPTY", "value" => "1")
-                                    )
-                                )
-                            )
-                        )
-                    )
-                )
-            )
-            expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
-            subject.before_enqueue_kubernetes_job
-          end
-        end
-
-        context "when TERM_ON_EMPTY environment is not set" do
-          it "ensures it is set to 1" do
-            manifest = hash_including(
-                "spec" => hash_including(
-                    "template" => hash_including(
-                        "spec" => hash_including(
-                            "containers" => array_including(
-                                hash_including(
-                                    "env" => array_including(
-                                        hash_including("name" => "TERM_ON_EMPTY", "value" => "1")
-                                    )
-                                )
-                            )
-                        )
-                    )
-                )
-            )
-            expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
-            subject.before_enqueue_kubernetes_job
-          end
-        end
-
-        context "when the namespace is not included" do
-          it "sets it to 'default'" do
-            manifest = hash_including(
-                "metadata" => hash_including(
-                    "namespace" => "default"
-                )
-            )
-            expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
-            subject.before_enqueue_kubernetes_job
-          end
-        end
-
-        context "when the namespace is set" do
-          before do
-            manifest = subject.default_manifest.dup
-            manifest["metadata"]["namespace"] = "staging"
-            allow(subject).to receive(:job_manifest).and_return(manifest)
-          end
-
-          it "retains it" do
-            manifest = hash_including(
-                "metadata" => hash_including(
-                    "namespace" => "staging"
-                )
-            )
-            expect(Kubeclient::Resource).to receive(:new).with(manifest).and_return(job)
-            subject.before_enqueue_kubernetes_job
-          end
-        end
-
-      end
-    end
-
-    context "for the gem-global max_workers setting" do
-      before do
-        allow(Resque::Kubernetes).to receive(:max_workers).and_return(workers)
       end
 
-      include_examples "max workers"
-    end
+      context "for the gem-global max_workers setting" do
+        before do
+          allow(Resque::Kubernetes).to receive(:max_workers).and_return(workers)
+        end
 
-    context "for the job-specific max_workers setting" do
-      before do
-        allow(Resque::Kubernetes).to receive(:max_workers).and_return(0)
-        allow(subject).to receive(:max_workers).and_return(workers)
+        include_examples "max workers"
       end
 
-      include_examples "max workers"
+      context "for the job-specific max_workers setting" do
+        before do
+          allow(Resque::Kubernetes).to receive(:max_workers).and_return(0)
+          allow(subject).to receive(:max_workers).and_return(workers)
+        end
+
+        include_examples "max workers"
+      end
     end
+  end
+
+  context "Pure Resque" do
+    subject { ThingExtendingJob }
+
+    include_examples "before enqueue callback"
+  end
+
+  context "ActiveJob (backed by Resque)" do
+    subject { ThingIncludingJob.new }
+
+    include_examples "before enqueue callback"
   end
 
 end


### PR DESCRIPTION
This modifies the `resque-kubernetes` so that it will work with ActiveJob, when configured to be backed by Resque. Most of this is documentation changes to show how to use this in ActiveJob. The difference is that Resque jobs use class methods, so you `extend` the class while ActiveJob uses instance methods so you `include` the module in the class. The code change is to update `Kuberentes::Resque::Job` so that when it's `included` we record the callback using ActiveJob's macros-style class method.

The `job_spec` file is changed to run the same specs when included or extended. The diff just looks ugly.

In addition to the doc changes for ActiveJob this fixes the docs such that `job_manifest` returns a `Hash` which is what the library expects.