### PR TITLE
Update to Kubeclient 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,26 +208,56 @@ end
 - We probably need better namespace support, particularly for reaping
   finished jobs and pods.
 
-## Development
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/keylime-toolbox/resque-kubernetes.
+
+1. Fork it (`https://github.com/[my-github-username]/kubeclient/fork`)
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Test your changes with `rake`, add new tests if needed
+4. Commit your changes (`git commit -am 'Add some feature'`)
+6. Push to the branch (`git push origin my-new-feature`)
+7. Open a new Pull Request
+
+
+### Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, 
-run `rake spec` to run the tests.
+run `rake` to run the test suite.
 
-You can run `bin/console` for an interactive prompt that will allow you to experiment.
+You can run `bin/console` for an interactive prompt that will allow you to
+experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`.
+Write test for any code that you add. Test all changes by running `rake`.
+This does the following, which you can also run separately while working.
+1. Tun unit tests: `rake spec`
+2. Make sure that your code matches the styles: `rubocop`
+3. Verify if any dependent gems have open CVEs (you must update these):
+   `rake bundle:audit` 
+
+### End to End Tests
+
+We don't run End to End (e2e) tests in the regular suite because
+they require a connection to a cluster. You can run these on your changes
+if you want to verify that the jobs are created correctly.
+
+This will use the default authentication on your system, which may is either
+the cluster the tests are running in (if you are doing that) or your Google
+Default Application Credentials, if you have `kubeclient` configured for
+a GKE cluster.
+
+```bash
+rspec --tag type:e2e
+```
+
+## Release
 
 To release a new version, update the version number in
 `lib/resque/kubernetes/version.rb` and the `CHANGELOG.md`, then run
 `bundle exec rake release`, which will create a git tag for the version,
 push git commits and tags, and push the `.gem` file to 
 [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at 
-https://github.com/keylime-toolbox/resque-kubernetes.
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -243,9 +243,8 @@ they require a connection to a cluster. You can run these on your changes
 if you want to verify that the jobs are created correctly.
 
 This will use the default authentication on your system, which may is either
-the cluster the tests are running in (if you are doing that) or your Google
-Default Application Credentials, if you have `kubeclient` configured for
-a GKE cluster.
+the cluster the tests are running in (if you are doing that), your `kubclient`
+configuration, or your Google Default Application Credentials.
 
 ```bash
 rspec --tag type:e2e

--- a/resque-kubernetes.gemspec
+++ b/resque-kubernetes.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "rubocop", "~> 0.52", ">= 0.52.1"
 
-  spec.add_dependency "kubeclient", "~> 3.0"
+  spec.add_dependency "kubeclient", ">= 2.2", "< 4.0"
   spec.add_dependency "resque", "~> 1.26"
 end

--- a/resque-kubernetes.gemspec
+++ b/resque-kubernetes.gemspec
@@ -25,10 +25,11 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "bundler-audit", "~> 0"
+  spec.add_development_dependency "googleauth", "~> 0.6"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "rubocop", "~> 0.52", ">= 0.52.1"
 
-  spec.add_dependency "kubeclient", "~> 2.2"
+  spec.add_dependency "kubeclient", "~> 3.0"
   spec.add_dependency "resque", "~> 1.26"
 end

--- a/spec/e2e/create_job_spec.rb
+++ b/spec/e2e/create_job_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "googleauth"
+
+RSpec.describe "Create a job", type: "e2e" do
+  class E2EThingExtendingJob
+    extend Resque::Kubernetes::Job
+
+    # rubocop:disable Metrics/MethodLength
+    def self.job_manifest
+      {
+          "metadata"   => {
+              "name"   => "thing",
+              "labels" => {"e2e-tests" => "E2EThingExtendingJob"}
+          },
+          "spec"     => {
+              "template" => {
+                  "spec" => {
+                      "containers" => [
+                        {
+                            "name"    => "e2e-test",
+                            "image"   => "ubuntu",
+                            "command" => ["pwd"]
+                        }
+                    ]
+                  }
+              }
+          }
+      }
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+
+  after do
+    resque_jobs = E2EThingExtendingJob.send(:jobs_client).get_jobs(
+        label_selector: "resque-kubernetes=job,e2e-tests=E2EThingExtendingJob"
+    )
+    resque_jobs.each do |job|
+      begin
+        E2EThingExtendingJob.send(:jobs_client).delete_job(job.metadata.name, job.metadata.namespace)
+      rescue KubeException => e
+        raise unless e.error_code == 404
+      end
+    end
+
+  end
+
+  it "launches a job in the cluster" do
+    # Don't run #before_enqueue_kubernetes_job because we don't want this test reaping finished jobs from elsewhere
+    E2EThingExtendingJob.send(:apply_kubernetes_job)
+
+    resque_jobs = E2EThingExtendingJob.send(:jobs_client).get_jobs(
+        label_selector: "resque-kubernetes=job,e2e-tests=E2EThingExtendingJob"
+    )
+    expect(resque_jobs.count).to eq 1
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,12 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "resque/kubernetes"
 
+RSpec.configure do |config|
+  config.order = "random"
+  config.filter_run_when_matching focus: true
+  config.filter_run_excluding type: "e2e"
+end
+
 def with_term_on_empty(value)
   old_value = ENV["TERM_ON_EMPTY"]
   ENV["TERM_ON_EMPTY"] = value


### PR DESCRIPTION
This PR changes the dependency on `kubeclient` to 3.0. We were already using the new `Kubeclient::Resource.new(manifest)` syntax (the breaking change between 2.2 and 3.0) so this doesn't require code changes to the gem.

To verify this I added an end-to-end tests that ensures we can launch a job in the cluster. This is _not_ run in the default test suite because it requires the machine that this runs on to be configured for access to a cluster.