### PR TITLE
Fix jobs continue to be created when there are more than max_workers

### DIFF
--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -172,7 +172,7 @@ module Resque
             namespace:      namespace
         )
         running = resque_jobs.reject { |job| job.spec.completions == job.status.succeeded }
-        running.size == max_workers
+        running.size >= max_workers
       end
 
       def adjust_manifest(manifest)

--- a/spec/e2e/create_job_spec.rb
+++ b/spec/e2e/create_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Create a job", type: "e2e" do
     # rubocop:disable Metrics/MethodLength
     def self.job_manifest
       {
-          "metadata"   => {
+          "metadata" => {
               "name"   => "thing",
               "labels" => {"e2e-tests" => "E2EThingExtendingJob"}
           },
@@ -18,12 +18,12 @@ RSpec.describe "Create a job", type: "e2e" do
               "template" => {
                   "spec" => {
                       "containers" => [
-                        {
-                            "name"    => "e2e-test",
-                            "image"   => "ubuntu",
-                            "command" => ["pwd"]
-                        }
-                    ]
+                          {
+                              "name"    => "e2e-test",
+                              "image"   => "ubuntu",
+                              "command" => ["pwd"]
+                          }
+                      ]
                   }
               }
           }

--- a/spec/resque/kubernetes/job_spec.rb
+++ b/spec/resque/kubernetes/job_spec.rb
@@ -144,6 +144,23 @@ describe Resque::Kubernetes::Job do
           end
         end
 
+        context "when more that maximum workers are running" do
+          let(:workers) { 1 }
+
+          before do
+            allow(jobs_client).to receive(:get_jobs).and_return(
+                [
+                    working_job, K8sStub.new(spec: {completions: 1}, status: {succeeded: 0})
+                ]
+            )
+          end
+
+          it "does not try to create a new job" do
+            expect(Kubeclient::Resource).not_to receive(:new)
+            subject.before_enqueue_kubernetes_job
+          end
+        end
+
         context "when matching, completed jobs exist" do
           let(:workers) { 2 }
 


### PR DESCRIPTION
Bug: #157714454

I found a production issue where 52 jobs running. There were 412 pods in the Running, ContainerCreating, or Pending stage. All of the jobs were created in the last 10 minutes

`max_workers` was the default value of 10.

This is happening because `Resque::Kubernetes::Job#jobs_maxed?` checks whether `running.size == max_workers`, but if the number running is greater than the max, it will continue to add jobs.

More jobs were running because I had hacked the system to increase the worker count for a short run. But as long as that number was > 10 it kept adding jobs.

This resolves that by checking if the number of running jobs is >= `max_workers`.