### PR TITLE
Refactor so that we do not pollute job class with our methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,4 +45,4 @@ Lint/UselessSetterCall:
   Exclude:
     # Rubocop is incorrectly flagging `term_on_empty` as local
     # See: https://github.com/bbatsov/rubocop/issues/5420
-    - lib/resque/kubernetes/job.rb
+    - lib/resque/kubernetes/jobs_manager.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# master (Not yet released)
+- Update to not pollute the job class with our methods
 # 0.8.0
 - Fix bug where enqueueing jobs would keep adding workers if worker count
   was _greater_ than `max_workers`

--- a/lib/resque/kubernetes.rb
+++ b/lib/resque/kubernetes.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
+require "resque/kubernetes/configurable"
 require "resque/kubernetes/context_factory"
 require "resque/kubernetes/deep_hash"
 require "resque/kubernetes/dns_safe_random"
 require "resque/kubernetes/job"
+require "resque/kubernetes/jobs_manager"
 require "resque/kubernetes/version"
 require "resque/kubernetes/worker"
-require "resque/kubernetes/configurable"
 
 module Resque
   # Run Resque Jobs as Kubernetes Jobs with autoscaling.

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "kubeclient"
-
 module Resque
   module Kubernetes
     # Resque hook to autoscale Kubernetes Jobs for workers.
@@ -89,13 +87,12 @@ module Resque
           return unless Resque::Kubernetes.environments.include?(Rails.env)
         end
 
-        reap_finished_jobs
-        apply_kubernetes_job
+        manager = JobsManager.new(self)
+        manager.reap_finished_jobs
+        manager.apply_kubernetes_job
       end
 
-      protected
-
-      # Return the maximum number of workers to autoscale the job to.
+      # The maximum number of workers to autoscale the job to.
       #
       # While the number of active Kubernetes Jobs is less than this number,
       # the gem will add new Jobs to auto-scale the workers.
@@ -117,105 +114,6 @@ module Resque
       #    end
       def max_workers
         Resque::Kubernetes.max_workers
-      end
-
-      private
-
-      def jobs_client
-        return @jobs_client if @jobs_client
-        @jobs_client = client("/apis/batch")
-      end
-
-      def client(scope)
-        context = ContextFactory.context
-        return unless context
-
-        Kubeclient::Client.new(
-            context.api_endpoint + scope,
-            context.api_version,
-            ssl_options:  context.ssl_options,
-            auth_options: context.auth_options
-        )
-      end
-
-      def finished_jobs
-        resque_jobs = jobs_client.get_jobs(label_selector: "resque-kubernetes=job")
-        resque_jobs.select { |job| job.spec.completions == job.status.succeeded }
-      end
-
-      def reap_finished_jobs
-        finished_jobs.each do |job|
-          begin
-            jobs_client.delete_job(job.metadata.name, job.metadata.namespace)
-          rescue KubeException => e
-            raise unless e.error_code == 404
-          end
-        end
-      end
-
-      def apply_kubernetes_job
-        manifest = DeepHash.new.merge!(job_manifest)
-        ensure_namespace(manifest)
-
-        # Do not start job if we have reached our maximum count
-        return if jobs_maxed?(manifest["metadata"]["name"], manifest["metadata"]["namespace"])
-
-        adjust_manifest(manifest)
-
-        job = Kubeclient::Resource.new(manifest)
-        jobs_client.create_job(job)
-      end
-
-      def jobs_maxed?(name, namespace)
-        resque_jobs = jobs_client.get_jobs(
-            label_selector: "resque-kubernetes=job,resque-kubernetes-group=#{name}",
-            namespace:      namespace
-        )
-        running = resque_jobs.reject { |job| job.spec.completions == job.status.succeeded }
-        running.size >= max_workers
-      end
-
-      def adjust_manifest(manifest)
-        add_labels(manifest)
-        ensure_term_on_empty(manifest)
-        ensure_reset_policy(manifest)
-        update_job_name(manifest)
-      end
-
-      def add_labels(manifest)
-        manifest.deep_add(%w[metadata labels resque-kubernetes], "job")
-        manifest["metadata"]["labels"]["resque-kubernetes-group"] = manifest["metadata"]["name"]
-        manifest.deep_add(%w[spec template metadata labels resque-kubernetes], "pod")
-      end
-
-      def ensure_term_on_empty(manifest)
-        manifest["spec"]["template"]["spec"] ||= {}
-        manifest["spec"]["template"]["spec"]["containers"] ||= []
-        manifest["spec"]["template"]["spec"]["containers"].each do |container|
-          container_term_on_empty(container)
-        end
-      end
-
-      def container_term_on_empty(container)
-        container["env"] ||= []
-        term_on_empty = container["env"].find { |env| env["name"] == "TERM_ON_EMPTY" }
-        unless term_on_empty
-          term_on_empty = {"name" => "TERM_ON_EMPTY"}
-          container["env"] << term_on_empty
-        end
-        term_on_empty["value"] = "1"
-      end
-
-      def ensure_reset_policy(manifest)
-        manifest["spec"]["template"]["spec"]["restartPolicy"] ||= "OnFailure"
-      end
-
-      def ensure_namespace(manifest)
-        manifest["metadata"]["namespace"] ||= "default"
-      end
-
-      def update_job_name(manifest)
-        manifest["metadata"]["name"] += "-#{DNSSafeRandom.random_chars}"
       end
     end
   end

--- a/lib/resque/kubernetes/jobs_manager.rb
+++ b/lib/resque/kubernetes/jobs_manager.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "kubeclient"
+
+module Resque
+  module Kubernetes
+    # Spins up Kubernetes Jobs to run Resque workers.
+    class JobsManager
+      attr_reader :owner
+      private :owner
+
+      def initialize(owner)
+        @owner = owner
+      end
+
+      def reap_finished_jobs
+        finished_jobs.each do |job|
+          begin
+            jobs_client.delete_job(job.metadata.name, job.metadata.namespace)
+          rescue KubeException => e
+            raise unless e.error_code == 404
+          end
+        end
+      end
+
+      def apply_kubernetes_job
+        manifest = DeepHash.new.merge!(owner.job_manifest)
+        ensure_namespace(manifest)
+
+        # Do not start job if we have reached our maximum count
+        return if jobs_maxed?(manifest["metadata"]["name"], manifest["metadata"]["namespace"])
+
+        adjust_manifest(manifest)
+
+        job = Kubeclient::Resource.new(manifest)
+        jobs_client.create_job(job)
+      end
+
+      private
+
+      def jobs_client
+        return @jobs_client if @jobs_client
+        @jobs_client = client("/apis/batch")
+      end
+
+      def client(scope)
+        context = ContextFactory.context
+        return unless context
+
+        Kubeclient::Client.new(
+            context.api_endpoint + scope,
+            context.api_version,
+            ssl_options:  context.ssl_options,
+            auth_options: context.auth_options
+        )
+      end
+
+      def finished_jobs
+        resque_jobs = jobs_client.get_jobs(label_selector: "resque-kubernetes=job")
+        resque_jobs.select { |job| job.spec.completions == job.status.succeeded }
+      end
+
+      def jobs_maxed?(name, namespace)
+        resque_jobs = jobs_client.get_jobs(
+            label_selector: "resque-kubernetes=job,resque-kubernetes-group=#{name}",
+            namespace:      namespace
+        )
+        running = resque_jobs.reject { |job| job.spec.completions == job.status.succeeded }
+        running.size >= owner.max_workers
+      end
+
+      def adjust_manifest(manifest)
+        add_labels(manifest)
+        ensure_term_on_empty(manifest)
+        ensure_reset_policy(manifest)
+        update_job_name(manifest)
+      end
+
+      def add_labels(manifest)
+        manifest.deep_add(%w[metadata labels resque-kubernetes], "job")
+        manifest["metadata"]["labels"]["resque-kubernetes-group"] = manifest["metadata"]["name"]
+        manifest.deep_add(%w[spec template metadata labels resque-kubernetes], "pod")
+      end
+
+      def ensure_term_on_empty(manifest)
+        manifest["spec"]["template"]["spec"] ||= {}
+        manifest["spec"]["template"]["spec"]["containers"] ||= []
+        manifest["spec"]["template"]["spec"]["containers"].each do |container|
+          container_term_on_empty(container)
+        end
+      end
+
+      def container_term_on_empty(container)
+        container["env"] ||= []
+        term_on_empty = container["env"].find { |env| env["name"] == "TERM_ON_EMPTY" }
+        unless term_on_empty
+          term_on_empty = {"name" => "TERM_ON_EMPTY"}
+          container["env"] << term_on_empty
+        end
+        term_on_empty["value"] = "1"
+      end
+
+      def ensure_reset_policy(manifest)
+        manifest["spec"]["template"]["spec"]["restartPolicy"] ||= "OnFailure"
+      end
+
+      def ensure_namespace(manifest)
+        manifest["metadata"]["namespace"] ||= "default"
+      end
+
+      def update_job_name(manifest)
+        manifest["metadata"]["name"] += "-#{DNSSafeRandom.random_chars}"
+      end
+    end
+  end
+end

--- a/spec/resque/kubernetes/job_spec.rb
+++ b/spec/resque/kubernetes/job_spec.rb
@@ -58,7 +58,7 @@ describe Resque::Kubernetes::Job do
   let(:jobs_client) { spy("jobs client") }
 
   before do
-    allow(subject).to receive(:jobs_client).and_return(jobs_client)
+    allow_any_instance_of(Resque::Kubernetes::JobsManager).to receive(:jobs_client).and_return(jobs_client)
   end
 
   shared_examples "before enqueue callback" do
@@ -74,7 +74,7 @@ describe Resque::Kubernetes::Job do
         end
 
         it "calls kubernetes APIs" do
-          expect(subject).to receive(:jobs_client).and_return(jobs_client)
+          expect_any_instance_of(Resque::Kubernetes::JobsManager).to receive(:jobs_client).and_return(jobs_client)
           subject.before_enqueue_kubernetes_job
         end
       end
@@ -93,7 +93,7 @@ describe Resque::Kubernetes::Job do
           end
 
           it "calls kubernetes APIs" do
-            expect(subject).to receive(:jobs_client).and_return(jobs_client)
+            expect_any_instance_of(Resque::Kubernetes::JobsManager).to receive(:jobs_client).and_return(jobs_client)
             subject.before_enqueue_kubernetes_job
           end
         end


### PR DESCRIPTION
When trying to integrate this with a `activejob-traffic_control` in an active job, I ran into an error because we defined `#client` on the class and so did `activejob-traffic_control`. We really shouldn't be defining any methods on the client expect ones required (the hook) or that we expose (`max_workers`, `job_manifest`). 

This resolves that by moving all our logic to a "manager" class and instantiating that in the hook. This makes the code much cleaner so it's a better direction anyway.

Note that this is a potentially breaking change because this now requires that `#job_manifest` and `#max_workers` are public methods. While we never documented them as otherwise they could have been private methods previously.