### PR TITLE
Pin kubeclient to <= 3.0.0 due to change in signature for Kubeclient::Config::Context#initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# master (not yet released)
+- Kubeclient may not be later than 3.0.0 due to change in signature of `Kubeclient::Config::Context#initialize`
+
 # v0.9.0
 - Update to not pollute the job class with our methods
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master (not yet released)
-- Kubeclient may not be later than 3.0.0 due to change in signature of `Kubeclient::Config::Context#initialize`
+- `kubeclient` may not be later than 3.0.0 due to change in signature of `Kubeclient::Config::Context#initialize`
+  in `kubeclient` 3.1.0
 
 # v0.9.0
 - Update to not pollute the job class with our methods

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ end
 Bug reports and pull requests are welcome on GitHub at
 https://github.com/keylime-toolbox/resque-kubernetes.
 
-1. Fork it (`https://github.com/[my-github-username]/kubeclient/fork`)
+1. Fork it (`https://github.com/[my-github-username]/resque-kubernetes/fork`)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Test your changes with `rake`, add new tests if needed
 4. Commit your changes (`git commit -am 'Add some feature'`)

--- a/resque-kubernetes.gemspec
+++ b/resque-kubernetes.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "rubocop", "~> 0.52", ">= 0.52.1"
 
-  spec.add_dependency "kubeclient", ">= 2.2", "< 4.0"
+  spec.add_dependency "kubeclient", ">= 2.2", "<= 3.0.0"
   spec.add_dependency "resque", "~> 1.26"
 end


### PR DESCRIPTION
Related to #14.

If you upgrade `kubeclient` to 3.1.0 or later you get an error:

> ArgumentError: wrong number of arguments (given 4, expected 5)

This is because in `kubeclient` 3.1.0 they [changed the signature](https://github.com/abonas/kubeclient/compare/v3.0.0...v3.1.0#diff-1d844cbeb767ae6ae4648ddc71f2d7fbR12) of `Kubeclient::Config::Context#initialize` to take an extra `namespace` parameter. As `Kubeclient::Config::Context` is not a documented interface (at least in the `README`) that can probably be construed to be an _internal_ API that we shouldn't use.

This PR limits the supported versions of `kubeclient` so that we can release an update on the 0.x releases that addresses this for people using older versions of `kubeclient`. I'll open a separate PR to depend on `kubeclient` 3.1.2 or 4.x that depends on the updates in 3.1.0 for better authorization and doesn't require using `Context` but that will be a breaking change so requires a major version update. This is to ensure that the 0.x line is still usable.