### PR TITLE
Clean up finished pods that have successfully completed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,9 @@ Style/FormatStringToken:
   EnforcedStyle: template
 Style/AsciiComments:
   Enabled: false
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - "gemfiles/*"
 
 Metrics/BlockLength:
   Exclude:
@@ -45,4 +48,4 @@ Lint/UselessSetterCall:
   Exclude:
     # Rubocop is incorrectly flagging `term_on_empty` as local
     # See: https://github.com/bbatsov/rubocop/issues/5420
-    - lib/resque/kubernetes/jobs_manager.rb
+    - lib/resque/kubernetes/manifest_conformance.rb

--- a/lib/resque/kubernetes.rb
+++ b/lib/resque/kubernetes.rb
@@ -8,6 +8,7 @@ require "resque/kubernetes/deep_hash"
 require "resque/kubernetes/dns_safe_random"
 require "resque/kubernetes/job"
 require "resque/kubernetes/jobs_manager"
+require "resque/kubernetes/manifest_conformance"
 require "resque/kubernetes/version"
 
 module Resque

--- a/lib/resque/kubernetes/dns_safe_random.rb
+++ b/lib/resque/kubernetes/dns_safe_random.rb
@@ -12,13 +12,13 @@ module Resque
       class << self
         # Returns an n-length string of DNS-safe characters.
         #
-        # n: The number of characters to return (default 5).
-        def random_chars(n = 5)
-          s = [SecureRandom.random_bytes(n)].pack("m*")
+        # number: The number of characters to return (default 5).
+        def random_chars(number = 5)
+          s = [SecureRandom.random_bytes(number)].pack("m*")
           s.delete!("=\n")
           s.tr!("+/_-", "0")
           s.tr!("A-Z", "a-z")
-          s[0...n]
+          s[0...number]
         end
       end
     end

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -82,13 +82,14 @@ module Resque
       end
 
       # A before_enqueue hook that adds worker jobs to the cluster.
-      def before_enqueue_kubernetes_job(*_)
+      def before_enqueue_kubernetes_job(*_args)
         if defined? Rails
           return unless Resque::Kubernetes.environments.include?(Rails.env)
         end
 
         manager = JobsManager.new(self)
         manager.reap_finished_jobs
+        manager.reap_finished_pods
         manager.apply_kubernetes_job
       end
 

--- a/lib/resque/kubernetes/manifest_conformance.rb
+++ b/lib/resque/kubernetes/manifest_conformance.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Resque
+  module Kubernetes
+    # Provides methods to ensure a mannifest conforms to a job specification
+    # and includes details needed for resque-kubernetes
+    module ManifestConformance
+      def adjust_manifest(manifest)
+        add_labels(manifest)
+        ensure_term_on_empty(manifest)
+        ensure_reset_policy(manifest)
+        update_job_name(manifest)
+      end
+
+      def add_labels(manifest)
+        manifest.deep_add(%w[metadata labels resque-kubernetes], "job")
+        manifest["metadata"]["labels"]["resque-kubernetes-group"] = manifest["metadata"]["name"]
+        manifest.deep_add(%w[spec template metadata labels resque-kubernetes], "pod")
+      end
+
+      def ensure_term_on_empty(manifest)
+        manifest["spec"]["template"]["spec"] ||= {}
+        manifest["spec"]["template"]["spec"]["containers"] ||= []
+        manifest["spec"]["template"]["spec"]["containers"].each do |container|
+          container_term_on_empty(container)
+        end
+      end
+
+      def container_term_on_empty(container)
+        container["env"] ||= []
+        term_on_empty = container["env"].find { |env| env["name"] == "INTERVAL" }
+        unless term_on_empty
+          term_on_empty = {"name" => "INTERVAL"}
+          container["env"] << term_on_empty
+        end
+        term_on_empty["value"] = "0"
+      end
+
+      def ensure_reset_policy(manifest)
+        manifest["spec"]["template"]["spec"]["restartPolicy"] ||= "OnFailure"
+      end
+
+      def ensure_namespace(manifest)
+        manifest["metadata"]["namespace"] ||= @default_namespace
+      end
+
+      def update_job_name(manifest)
+        manifest["metadata"]["name"] += "-#{DNSSafeRandom.random_chars}"
+      end
+    end
+  end
+end

--- a/resque-kubernetes.gemspec
+++ b/resque-kubernetes.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "resque/kubernetes/version"
 
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "googleauth", "~> 0.6"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
-  spec.add_development_dependency "rubocop", "~> 0.52", ">= 0.52.1"
+  # Pinned less than 0.56.0 until this is resolved: https://github.com/rubocop-hq/rubocop/issues/5975
+  spec.add_development_dependency "rubocop", "~> 0.52", ">= 0.52.1", "< 0.56.0"
 
   spec.add_dependency "kubeclient", ">= 3.1.2", "< 5.0"
   spec.add_dependency "resque", "~> 1.26"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "resque/kubernetes"
 
 RSpec.configure do |config|


### PR DESCRIPTION
This addresses #20 

In production we are spinning up and deleting thousands of new pods a day. Eventually the overhead of carrying these completed pods is leading to timeouts connecting to the API server (specifically DNS timeouts). If we can keep the pods cleaned up that keeps the system more responsive.

In #4 we removed the original code to reap completed pods because it was removing pods that were killed for exceeding memory. This adjust the original code so that it only reaps pods with all containers reporting a "Completed" status. This will retain any pods that list "OOMKilled" as their status for inspection later.