### PR TITLE
Retry when a timeout occurs connecting to the Kubernetes API server

### DIFF
--- a/lib/resque/kubernetes.rb
+++ b/lib/resque/kubernetes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "retriable"
+
 require "resque/kubernetes/configurable"
 require "resque/kubernetes/context/kubectl"
 require "resque/kubernetes/context/well_known"
@@ -9,6 +11,7 @@ require "resque/kubernetes/dns_safe_random"
 require "resque/kubernetes/job"
 require "resque/kubernetes/jobs_manager"
 require "resque/kubernetes/manifest_conformance"
+require "resque/kubernetes/retriable_client"
 require "resque/kubernetes/version"
 
 module Resque

--- a/lib/resque/kubernetes/jobs_manager.rb
+++ b/lib/resque/kubernetes/jobs_manager.rb
@@ -62,8 +62,12 @@ module Resque
       end
 
       def client(scope)
-        return Resque::Kubernetes.kubeclient if Resque::Kubernetes.kubeclient
+        return RetriableClient.new(Resque::Kubernetes.kubeclient) if Resque::Kubernetes.kubeclient
+        client = build_client(scope)
+        RetriableClient.new(client) if client
+      end
 
+      def build_client(scope)
         context = ContextFactory.context
         return unless context
         @default_namespace = context.namespace if context.namespace

--- a/lib/resque/kubernetes/manifest_conformance.rb
+++ b/lib/resque/kubernetes/manifest_conformance.rb
@@ -2,7 +2,7 @@
 
 module Resque
   module Kubernetes
-    # Provides methods to ensure a mannifest conforms to a job specification
+    # Provides functions to ensure a manifest conforms to a job specification
     # and includes details needed for resque-kubernetes
     module ManifestConformance
       def adjust_manifest(manifest)

--- a/lib/resque/kubernetes/retriable_client.rb
+++ b/lib/resque/kubernetes/retriable_client.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Resque
+  module Kubernetes
+    # Wraps Kubeclient::Client to retry timeout errors
+    class RetriableClient
+      attr_accessor :kubeclient
+
+      def initialize(client)
+        self.kubeclient = client
+      end
+
+      def method_missing(method, *args, &block)
+        if kubeclient.respond_to?(method)
+          Retriable.retriable(on: {Kubeclient::HttpError => /Timed out/}) do
+            kubeclient.send(method, *args, &block)
+          end
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method)
+        kubeclient.respond_to?(method)
+      end
+    end
+  end
+end

--- a/resque-kubernetes.gemspec
+++ b/resque-kubernetes.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "kubeclient", ">= 3.1.2", "< 5.0"
   spec.add_dependency "resque", "~> 1.26"
+  spec.add_dependency "retriable", "~> 3.0"
 end

--- a/spec/resque/kubernetes/retriable_client_spec.rb
+++ b/spec/resque/kubernetes/retriable_client_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Resque::Kubernetes::RetriableClient do
+  let(:kubeclient) { double("Kubeclient::Client", get_pods: "datum") }
+
+  subject { Resque::Kubernetes::RetriableClient.new(kubeclient) }
+
+  context "when a method on the client raises Kubeclient::HttpError" do
+    let(:error) { Kubeclient::HttpError.new(0, message, "body") }
+    context "and that has a 'Timed out' message" do
+      before do
+        expect(kubeclient).to receive(:get_pods).exactly(2).times.and_raise(error)
+      end
+
+      let(:message) { "Timed out connecting to server" }
+
+      it "retries the call" do
+
+        expect { subject.get_pods }.to raise_error Kubeclient::HttpError
+      end
+    end
+
+    context "and that has a message other than 'Timed out'" do
+      before do
+        expect(kubeclient).to receive(:get_pods).once.and_raise(error)
+      end
+
+      let(:message) { "Resource not found" }
+
+      it "raises the error immediately without retry" do
+        expect { subject.get_pods }.to raise_error Kubeclient::HttpError
+      end
+    end
+  end
+
+  context "when a method on the client raises an error other than Kubeclient::HttpError" do
+    before do
+      allow(kubeclient).to receive(:get_pods).and_raise(StandardError.new("message"))
+    end
+
+    it "raises the error immediately without retry" do
+      expect { subject.get_pods }.to raise_error StandardError
+    end
+  end
+
+  context "when a method on the client returns a value" do
+    it "returns the value without errors" do
+      expect(subject.get_pods).to eq "datum"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,16 @@ RSpec.configure do |config|
   config.filter_run_when_matching focus: true
   config.filter_run_excluding type: "e2e"
 end
+
+# In tests, don't do exponential back-off, and don't pause between tries
+Retriable.configure do |c|
+  c.multiplier    = 1.0
+  c.rand_factor   = 0.0
+  c.base_interval = 0
+  c.tries         = 2
+
+  c.contexts.keys.each do |context|
+    c.contexts[context][:tries]         = 2
+    c.contexts[context][:base_interval] = 0
+  end
+end


### PR DESCRIPTION
Internal issue #162461745

Once in a while a call from `Resque::Kubernetes` through `Kubeclient` will end up with an error:

>  `Kubeclient::HttpError` Error message: Timed out connecting to server

We've had this happen when `Resque::Kuberentes` is trying to list list finished jobs and when it's trying to spin up a new worker job. My guess is this happens when the node making the request is under high CPU load (that's been my past experience with network issues in Kubernetes).

As timeout errors are generally recoverable, this PR opts to retry any "Timed out" errors. The default is to retry 10 times with exponential backoff, but the gem doesn't configure `Retriable` so that the implementing application can set those values.

This does add a new dependency to the gem but I think the net gain is valuable and better to include a dependent gem than to try to write our own exponential backoff.