### PR TITLE
Fix `ContextFactory.context` function: it should not return an Array when all the contexts are not `applicable?`

### DIFF
--- a/lib/resque/kubernetes/context_factory.rb
+++ b/lib/resque/kubernetes/context_factory.rb
@@ -18,6 +18,8 @@ module Resque
             context = context_type.new
             return context.context if context.applicable?
           end
+
+          nil
         end
       end
     end


### PR DESCRIPTION
Hi @jeremywadsack ,

In my test suite, I have the following error:

```ruby
undefined method `namespace' for #<Array:0x000000000a5f7648>
shared/bundle/ruby/2.3.0/gems/resque-kubernetes-1.3.0/lib/resque/kubernetes/jobs_manager.rb:73:in `build_client'
shared/bundle/ruby/2.3.0/gems/resque-kubernetes-1.3.0/lib/resque/kubernetes/jobs_manager.rb:66:in `client'
shared/bundle/ruby/2.3.0/gems/resque-kubernetes-1.3.0/lib/resque/kubernetes/jobs_manager.rb:57:in `jobs_client'
shared/bundle/ruby/2.3.0/gems/resque-kubernetes-1.3.0/lib/resque/kubernetes/jobs_manager.rb:79:in `finished_jobs'
shared/bundle/ruby/2.3.0/gems/resque-kubernetes-1.3.0/lib/resque/kubernetes/jobs_manager.rb:22:in `reap_finished_jobs'
bundle/ruby/2.3.0/gems/resque-kubernetes-1.3.0/lib/resque/kubernetes/job.rb:91:in `before_enqueue_kubernetes_job'
```