### PR TITLE
[Proposal] Replace the `environments` property by a more flexible `enabled` property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+**Breaking Change:**
+- The `environment` configuration as been replaced by a more flexible `activated` properties.
+
+Here's how to migrate from the `environment` property to the `activated` property:
+
+Before:
+```ruby
+# config/initializers/resque-kubernetes.rb
+
+Resque::Kubernetes.configuration do |config|
+ config.environments << "staging"
+ config.max_workers = 10
+end
+```
+
+After:
+```ruby
+# config/initializers/resque-kubernetes.rb
+
+Resque::Kubernetes.configuration do |config|
+ config.activated   = Rails.env.production? || Rails.env.staging?
+ config.max_workers = 10
+end
+```
+
+⚠️ By default, this gem is not activated.
+
 # v1.3.0
 - Retry when a timeout occurs connecting to the Kubernetes API server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 **Breaking Change:**
-- The `environment` configuration as been replaced by a more flexible `activated` properties.
+- The `environments` configuration as been replaced by a more flexible `activated` properties.
 
-Here's how to migrate from the `environment` property to the `activated` property:
+Here's how to migrate from the `environments` property to the `activated` property:
 
 Before:
 ```ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 **Breaking Change:**
-- The `environments` configuration as been replaced by a more flexible `activated` properties.
+- The `environments` configuration as been replaced by a more flexible `enabled` properties.
 
-Here's how to migrate from the `environments` property to the `activated` property:
+Here's how to migrate from the `environments` property to the `enabled` property:
 
 Before:
 ```ruby
@@ -18,12 +18,12 @@ After:
 # config/initializers/resque-kubernetes.rb
 
 Resque::Kubernetes.configuration do |config|
- config.activated   = Rails.env.production? || Rails.env.staging?
+ config.enabled     = Rails.env.production? || Rails.env.staging?
  config.max_workers = 10
 end
 ```
 
-⚠️ By default, this gem is not activated.
+⚠️ By default, this gem is no enabled.
 
 # v1.3.0
 - Retry when a timeout occurs connecting to the Kubernetes API server

--- a/README.md
+++ b/README.md
@@ -152,19 +152,16 @@ your project:
 # config/initializers/resque-kubernetes.rb
 
 Resque::Kubernetes.configuration do |config|
- config.environments << "staging"
+ config.activated = Rails.env.production? || Rails.env.staging?
  config.max_workers = 10
 end
 ```
 
-### `environments`
+### `activated`
 
-> This only works under Rails, when `Rails.env` is set.
+⚠️ By default, the `activated` property is set to `false` which means that, by default, this plugin will not be launched.
 
-By default `Resque::Kubernetes` will only manage Kubernetes Jobs in
-`:production`. If you want to add other environments you can update this list
-(`config.environments << "staging"`) or replace it (`config.environments =
-["production", "development"]`).
+You should not activate this Resque plugin in environments that are not run inside a Kubernetes (for example, your CI env).
 
 ### `max_workers`
 

--- a/README.md
+++ b/README.md
@@ -152,16 +152,16 @@ your project:
 # config/initializers/resque-kubernetes.rb
 
 Resque::Kubernetes.configuration do |config|
- config.activated = Rails.env.production? || Rails.env.staging?
+ config.enabled     = Rails.env.production? || Rails.env.staging?
  config.max_workers = 10
 end
 ```
 
-### `activated`
+### `enabled`
 
-⚠️ By default, the `activated` property is set to `false` which means that, by default, this plugin will not be launched.
+⚠️ By default, the `enabled` property is set to `false` which means that, by default, this plugin will not be launched.
 
-You should not activate this Resque plugin in environments that are not run inside a Kubernetes (for example, your CI env).
+You should not enable this Resque plugin in environments that are not run inside a Kubernetes (for example, your CI env).
 
 ### `max_workers`
 

--- a/lib/resque/kubernetes.rb
+++ b/lib/resque/kubernetes.rb
@@ -19,8 +19,8 @@ module Resque
   module Kubernetes
     extend Configurable
 
-    # By default only manage kubernetes jobs in :production
-    define_setting :environments, ["production"]
+    # By default, this plugin is not active.
+    define_setting :activated, false
 
     # Limit the number of workers that should be spun up, default 10
     define_setting :max_workers, 10

--- a/lib/resque/kubernetes.rb
+++ b/lib/resque/kubernetes.rb
@@ -20,7 +20,7 @@ module Resque
     extend Configurable
 
     # By default, this plugin is not active.
-    define_setting :activated, false
+    define_setting :enabled, false
 
     # Limit the number of workers that should be spun up, default 10
     define_setting :max_workers, 10

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -83,9 +83,7 @@ module Resque
 
       # A before_enqueue hook that adds worker jobs to the cluster.
       def before_enqueue_kubernetes_job(*_args)
-        if defined? Rails
-          return unless Resque::Kubernetes.environments.include?(Rails.env)
-        end
+        return unless Resque::Kubernetes.activated
 
         manager = JobsManager.new(self)
         manager.reap_finished_jobs

--- a/lib/resque/kubernetes/job.rb
+++ b/lib/resque/kubernetes/job.rb
@@ -83,7 +83,7 @@ module Resque
 
       # A before_enqueue hook that adds worker jobs to the cluster.
       def before_enqueue_kubernetes_job(*_args)
-        return unless Resque::Kubernetes.activated
+        return unless Resque::Kubernetes.enabled
 
         manager = JobsManager.new(self)
         manager.reap_finished_jobs

--- a/spec/resque/kubernetes/job_spec.rb
+++ b/spec/resque/kubernetes/job_spec.rb
@@ -84,16 +84,16 @@ describe Resque::Kubernetes::Job do
         end
       end
 
-      context "when `activated` is not set by the user" do
+      context "when `enabled` is not set by the user" do
         it "does not make any kubernetes calls" do
           expect_any_instance_of(Resque::Kubernetes::JobsManager).not_to receive(:client)
           subject.before_enqueue_kubernetes_job
         end
       end
 
-      context "when `activated` is set to `true` by the user" do
+      context "when `enabled` is set to `true` by the user" do
         before do
-          allow(Resque::Kubernetes).to receive(:activated).and_return(true)
+          allow(Resque::Kubernetes).to receive(:enabled).and_return(true)
         end
 
         it "calls kubernetes APIs" do
@@ -104,9 +104,9 @@ describe Resque::Kubernetes::Job do
         end
       end
 
-      context "when `activated` is set to `false` by the user" do
+      context "when `enabled` is set to `false` by the user" do
         before do
-          allow(Resque::Kubernetes).to receive(:activated).and_return(false)
+          allow(Resque::Kubernetes).to receive(:enabled).and_return(false)
         end
 
         it "does not make any kubernetes calls" do

--- a/spec/resque/kubernetes/job_spec.rb
+++ b/spec/resque/kubernetes/job_spec.rb
@@ -84,14 +84,7 @@ describe Resque::Kubernetes::Job do
         end
       end
 
-      context "when `enabled` is not set by the user" do
-        it "does not make any kubernetes calls" do
-          expect_any_instance_of(Resque::Kubernetes::JobsManager).not_to receive(:client)
-          subject.before_enqueue_kubernetes_job
-        end
-      end
-
-      context "when `enabled` is set to `true` by the user" do
+      context "when `enabled` is set to `true`" do
         before do
           allow(Resque::Kubernetes).to receive(:enabled).and_return(true)
         end
@@ -104,7 +97,7 @@ describe Resque::Kubernetes::Job do
         end
       end
 
-      context "when `enabled` is set to `false` by the user" do
+      context "when `enabled` is set to `false`" do
         before do
           allow(Resque::Kubernetes).to receive(:enabled).and_return(false)
         end

--- a/spec/resque/kubernetes/job_spec.rb
+++ b/spec/resque/kubernetes/job_spec.rb
@@ -84,9 +84,16 @@ describe Resque::Kubernetes::Job do
         end
       end
 
-      context "when Rails.env is not defined" do
+      context "when `activated` is not set by the user" do
+        it "does not make any kubernetes calls" do
+          expect_any_instance_of(Resque::Kubernetes::JobsManager).not_to receive(:client)
+          subject.before_enqueue_kubernetes_job
+        end
+      end
+
+      context "when `activated` is set to `true` by the user" do
         before do
-          expect(defined? Rails).not_to be true
+          allow(Resque::Kubernetes).to receive(:activated).and_return(true)
         end
 
         it "calls kubernetes APIs" do
@@ -97,36 +104,14 @@ describe Resque::Kubernetes::Job do
         end
       end
 
-      context "when Rails.env is defined" do
-        let(:rails_stub) { Class.new }
-
+      context "when `activated` is set to `false` by the user" do
         before do
-          stub_const("Rails", rails_stub)
-          allow(rails_stub).to receive(:env).and_return("test")
+          allow(Resque::Kubernetes).to receive(:activated).and_return(false)
         end
 
-        context "and is included in the supported environments" do
-          before do
-            allow(Resque::Kubernetes).to receive(:environments).and_return(["test"])
-          end
-
-          it "calls kubernetes APIs" do
-            expect_any_instance_of(Resque::Kubernetes::JobsManager).to receive(:client).at_least(:once) do
-              client
-            end
-            subject.before_enqueue_kubernetes_job
-          end
-        end
-
-        context "and is not included in the supported environments" do
-          before do
-            allow(Resque::Kubernetes).to receive(:environments).and_return(["production"])
-          end
-
-          it "does not make any kubernetes calls" do
-            expect_any_instance_of(Resque::Kubernetes::JobsManager).not_to receive(:client)
-            subject.before_enqueue_kubernetes_job
-          end
+        it "does not make any kubernetes calls" do
+          expect_any_instance_of(Resque::Kubernetes::JobsManager).not_to receive(:client)
+          subject.before_enqueue_kubernetes_job
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,10 @@ RSpec.configure do |config|
   config.order = "random"
   config.filter_run_when_matching focus: true
   config.filter_run_excluding type: "e2e"
+
+  config.before(:each) do
+    allow(Resque::Kubernetes).to receive(:enabled).and_return(true)
+  end
 end
 
 # In tests, don't do exponential back-off, and don't pause between tries


### PR DESCRIPTION
Hi @jeremywadsack,

I'm running this gem in a quite complex environment where some parts of the code are run inside Kubernetes and some are run elsewhere.

So the `environments` property is not flexible enough to allow me express all the possibilities.

We can simplify your code and improve the configuration flexibility of this gem by replacing the `environments` property by a simpler, boolean based, `activated` property where people will have "to explain" when to activate this gem.

WDYT ?