### PR TITLE
Add support for resque 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# (Unreleased)
+- Allow resque 2.0 but retain support for 1.26 or later 
+
 # v1.3.0
 - Retry when a timeout occurs connecting to the Kubernetes API server
 

--- a/resque-kubernetes.gemspec
+++ b/resque-kubernetes.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.52", ">= 0.52.1", "< 0.56.0"
 
   spec.add_dependency "kubeclient", ">= 3.1.2", "< 5.0"
-  spec.add_dependency "resque", "~> 1.26"
+  spec.add_dependency "resque", ">= 1.26"
   spec.add_dependency "retriable", "~> 3.0"
 end


### PR DESCRIPTION
Resque 2.0 was released in November. The breaking change is primarily that it now requires ruby >= 2.3.0. There were no changes that affect this gem.

I've tested this change with both resque 2.0.0 and 1.27.4.