### PR TITLE
Fix syntax

### DIFF
--- a/lib/resque/kubernetes/jobs_manager.rb
+++ b/lib/resque/kubernetes/jobs_manager.rb
@@ -72,7 +72,12 @@ module Resque
         return unless context
         @default_namespace = context.namespace if context.namespace
 
-        Kubeclient::Client.new(context.endpoint + scope, context.version, context.options)
+        case RUBY_VERSION
+        when /^(3\.\d+|2\.[789])/
+          Kubeclient::Client.new(context.endpoint + scope, context.version, **context.options)
+        else
+          Kubeclient::Client.new(context.endpoint + scope, context.version, context.options)
+        end
       end
 
       def finished_jobs


### PR DESCRIPTION
Ruby 3 doesn't allow for the automatic expansion of hashes as the last argument of a function anymore. This just adds a minor change to expand an argument in the case of a ruby version that requires it.