### PR TITLE
Fix missing queue_as

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ modify the class with two things:
 ```ruby
 class ResourceIntensiveJob < ApplicationJob
   include Resque::Kubernetes::Job
+  queue_as :high_memory
 
   def perform
     # ... your existing code
@@ -117,7 +118,7 @@ class ResourceIntensiveJob < ApplicationJob
                 image: us.gcr.io/project-id/some-resque-worker
                 env:
                 - name: QUEUE
-                  value: high-memory
+                  value: high_memory
       MANIFEST
     )
   end


### PR DESCRIPTION
Job needs to be placed into the same queue as it is defined in the QUEUE environment variable. Otherwise it will not be processed and lay around as pending